### PR TITLE
Change background color to blue and text to white

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #007bff;
+  --foreground: #ffffff;
 }
 
 @theme inline {
@@ -14,8 +14,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #007bff;
+    --foreground: #ffffff;
   }
 }
 


### PR DESCRIPTION
I've changed the --background CSS variable to #007bff and the --foreground CSS variable to #ffffff in src/app/globals.css. This change applies to both light and dark themes for a consistent blue background.